### PR TITLE
add  time_zone configutation to users

### DIFF
--- a/decidim-core/app/commands/decidim/update_account.rb
+++ b/decidim-core/app/commands/decidim/update_account.rb
@@ -38,6 +38,7 @@ module Decidim
       @user.email = @form.email
       @user.personal_url = @form.personal_url
       @user.about = @form.about
+      @user.time_zone = @form.time_zone
     end
 
     def update_avatar

--- a/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
+++ b/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
@@ -25,7 +25,7 @@ module Decidim
       #
       # Returns a String.
       def organization_time_zone
-        @organization_time_zone ||= current_organization.time_zone ||= current_user.time_zone
+        @organization_time_zone ||= current_organization.time_zone || current_user.time_zone
       end
     end
   end

--- a/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
+++ b/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
@@ -25,7 +25,7 @@ module Decidim
       #
       # Returns a String.
       def organization_time_zone
-        @organization_time_zone ||= current_organization.time_zone || current_user.time_zone
+        @organization_time_zone ||= current_user.time_zone.presence || current_organization.time_zone
       end
     end
   end

--- a/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
+++ b/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
@@ -25,7 +25,7 @@ module Decidim
       #
       # Returns a String.
       def organization_time_zone
-        @organization_time_zone ||= current_user.time_zone.presence || current_organization.time_zone
+        @organization_time_zone ||= current_user&.time_zone.presence || current_organization.time_zone
       end
     end
   end

--- a/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
+++ b/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
@@ -25,7 +25,7 @@ module Decidim
       #
       # Returns a String.
       def organization_time_zone
-        @organization_time_zone ||= current_organization.time_zone
+        @organization_time_zone ||= current_organization.time_zone ||= current_user.time_zone
       end
     end
   end

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -29,7 +29,7 @@ module Decidim
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }
-    validates :time_zone, time_zone: true
+    validates :time_zone, time_zone: true, if: -> { time_zone.present? }
 
     validate :unique_email
     validate :unique_nickname

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -18,6 +18,7 @@ module Decidim
     attribute :remove_avatar, Boolean, default: false
     attribute :personal_url
     attribute :about
+    attribute :time_zone
 
     validates :name, presence: true
     validates :email, presence: true, 'valid_email_2/email': { disposable: true }
@@ -28,6 +29,8 @@ module Decidim
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }
+    validates :time_zone, presence: true
+    validates :time_zone, time_zone: true
 
     validate :unique_email
     validate :unique_nickname

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -29,8 +29,7 @@ module Decidim
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }
-    validates :time_zone, presence: true
-    validates :time_zone, time_zone: true
+    validates :time_zone, presence: true, time_zone: true
 
     validate :unique_email
     validate :unique_nickname

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -29,7 +29,7 @@ module Decidim
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }
-    validates :time_zone, presence: true, time_zone: true
+    validates :time_zone, time_zone: true
 
     validate :unique_email
     validate :unique_nickname

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -47,7 +47,7 @@ module Decidim
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
-    validates :time_zone, presence: true, time_zone: true
+    validates :time_zone, time_zone: true
 
     validate :all_roles_are_valid
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -47,7 +47,7 @@ module Decidim
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
-    validates :time_zone, time_zone: true, if: -> { timezone.present? }
+    validates :time_zone, time_zone: true, if: -> { time_zone.present? }
 
     validate :all_roles_are_valid
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -47,7 +47,7 @@ module Decidim
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
-    validates :time_zone, time_zone: true
+    validates :time_zone, time_zone: true, if: -> { timezone.present? }
 
     validate :all_roles_are_valid
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -47,6 +47,7 @@ module Decidim
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
+    validates :time_zone, presence: true, time_zone: true
 
     validate :all_roles_are_valid
 

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -25,6 +25,8 @@
           ) %>
       <p class="help-text"><%= t(".available_locales_helper") %></p>
 
+      <%= f.time_zone_select :time_zone %>
+
       <% if @account.errors[:password].any? || @account.errors[:password_confirmation].any? %>
         <%= render partial: "password_fields", locals: { form: f } %>
       <% else %>

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -25,7 +25,8 @@
           ) %>
       <p class="help-text"><%= t(".available_locales_helper") %></p>
 
-      <%= f.time_zone_select :time_zone %>
+      <%= f.time_zone_select :time_zone, nil, default: organization_time_zone %>
+      <p class="help-text"><%= t(".time_zone_helper") %></p>
 
       <% if @account.errors[:password].any? || @account.errors[:password_confirmation].any? %>
         <%= render partial: "password_fields", locals: { form: f } %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -135,6 +135,7 @@ en:
         success: Your account was successfully deleted.
       show:
         available_locales_helper: Choose the language you want to use to browse and receive notifications in Decidim
+        time_zone_helper: Use your personal time zone to display dates in your local time when you are logged in
         change_password: Change password
         update_account: Update account
       update:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -135,8 +135,8 @@ en:
         success: Your account was successfully deleted.
       show:
         available_locales_helper: Choose the language you want to use to browse and receive notifications in Decidim
-        time_zone_helper: Use your personal time zone to display dates in your local time when you are logged in
         change_password: Change password
+        time_zone_helper: Use your personal time zone to display dates in your local time when you are logged in
         update_account: Update account
       update:
         error: There was a problem updating your account.

--- a/decidim-core/db/migrate/20220823094517_add_time_zone_to_users.rb
+++ b/decidim-core/db/migrate/20220823094517_add_time_zone_to_users.rb
@@ -2,6 +2,6 @@
 
 class AddTimeZoneToUsers < ActiveRecord::Migration[6.0]
   def change
-    add_column :decidim_users, :time_zone, :string, limit: 255, default: "UTC"
+    add_column :decidim_users, :time_zone, :string
   end
 end

--- a/decidim-core/db/migrate/20220823094517_add_time_zone_to_users.rb
+++ b/decidim-core/db/migrate/20220823094517_add_time_zone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_users, :time_zone, :string, limit: 255, default: "UTC"
+  end
+end

--- a/decidim-core/db/migrate/20220823094517_add_time_zone_to_users.rb
+++ b/decidim-core/db/migrate/20220823094517_add_time_zone_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTimeZoneToUsers < ActiveRecord::Migration[6.0]
   def change
     add_column :decidim_users, :time_zone, :string, limit: 255, default: "UTC"

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -17,7 +17,8 @@ module Decidim
         remove_avatar: nil,
         personal_url: "https://example.org",
         about: "This is a description of me",
-        locale: "es"
+        locale: "es",
+        time_zone: "UTC"
       }
     end
 
@@ -32,7 +33,8 @@ module Decidim
         remove_avatar: data[:remove_avatar],
         personal_url: data[:personal_url],
         about: data[:about],
-        locale: data[:locale]
+        locale: data[:locale],
+        time_zone: data[:time_zone]
       ).with_context(current_organization: user.organization, current_user: user)
     end
 
@@ -75,6 +77,11 @@ module Decidim
       it "updates the language preference" do
         expect { command.call }.to broadcast(:ok)
         expect(user.reload.locale).to eq("es")
+      end
+
+      it "updates the time zone" do
+        expect { command.call }.to broadcast(:ok)
+        expect(user.reload.time_zone).to eq("UTC")
       end
 
       describe "updating the email" do

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -18,7 +18,7 @@ module Decidim
         personal_url: "https://example.org",
         about: "This is a description of me",
         locale: "es",
-        time_zone: "UTC"
+        time_zone: timezone
       }
     end
 
@@ -48,6 +48,14 @@ module Decidim
         old_name = user.name
         expect { command.call }.to broadcast(:invalid)
         expect(user.reload.name).to eq(old_name)
+      end
+
+      context "when timezone is invalid" do
+        let(:timezone) { "giberish" }
+
+        it "returns invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
       end
     end
 
@@ -79,9 +87,22 @@ module Decidim
         expect(user.reload.locale).to eq("es")
       end
 
-      it "updates the time zone" do
-        expect { command.call }.to broadcast(:ok)
-        expect(user.reload.time_zone).to eq("UTC")
+      context "when timezone is defined" do
+        let(:timezone) { "UTC" }
+
+        it "updates the time zone" do
+          expect { command.call }.to broadcast(:ok)
+          expect(user.reload.time_zone).to eq("UTC")
+        end
+      end
+
+      context "when timezone is not defined" do
+        let(:timezone) { "" }
+
+        it "updates the time zone" do
+          expect { command.call }.to broadcast(:ok)
+          expect(user.reload.time_zone).to eq("")
+        end
       end
 
       describe "updating the email" do

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -6,6 +6,7 @@ module Decidim
   describe UpdateAccount do
     let(:command) { described_class.new(user, form) }
     let(:user) { create(:user, :confirmed) }
+    let(:time_zone) { "UTC" }
     let(:data) do
       {
         name: user.name,
@@ -18,7 +19,7 @@ module Decidim
         personal_url: "https://example.org",
         about: "This is a description of me",
         locale: "es",
-        time_zone: timezone
+        time_zone: time_zone
       }
     end
 
@@ -51,7 +52,7 @@ module Decidim
       end
 
       context "when timezone is invalid" do
-        let(:timezone) { "giberish" }
+        let(:time_zone) { "giberish" }
 
         it "returns invalid" do
           expect { command.call }.to broadcast(:invalid)
@@ -88,8 +89,6 @@ module Decidim
       end
 
       context "when timezone is defined" do
-        let(:timezone) { "UTC" }
-
         it "updates the time zone" do
           expect { command.call }.to broadcast(:ok)
           expect(user.reload.time_zone).to eq("UTC")
@@ -97,7 +96,7 @@ module Decidim
       end
 
       context "when timezone is not defined" do
-        let(:timezone) { "" }
+        let(:time_zone) { "" }
 
         it "updates the time zone" do
           expect { command.call }.to broadcast(:ok)

--- a/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
+++ b/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
@@ -96,11 +96,30 @@ module Decidim
       it "controller uses London" do
         expect(controller.organization_time_zone).to eq("London")
       end
+
+      it "Time uses UTC zone within the controller scope" do
+        controller.use_organization_time_zone do
+          expect(Time.zone.name).to eq("London")
+        end
+      end
+
+      it "Time uses Rails timezone outside the controller scope" do
+        expect(Time.zone.name).to eq("UTC")
+      end
     end
 
     context "when user's time zone in not present" do
       let(:time_zone) { utc_time_zone }
       let(:user_time_zone) { "" }
+
+      it "controller uses time zone of organization" do
+        expect(controller.organization_time_zone).to eq(utc_time_zone)
+      end
+    end
+
+    context "when user is not present" do
+      let(:time_zone) { utc_time_zone }
+      let(:user) { nil }
 
       it "controller uses time zone of organization" do
         expect(controller.organization_time_zone).to eq(utc_time_zone)

--- a/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
+++ b/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
@@ -7,9 +7,12 @@ module Decidim
     let(:utc_time_zone) { "UTC" }
     let(:alt_time_zone) { "Hawaii" }
     let(:organization) { create(:organization, time_zone: time_zone) }
+    let(:user) { create :user, :confirmed, organization: organization, time_zone: user_time_zone }
+    let(:user_time_zone) { "" }
 
     before do
       request.env["decidim.current_organization"] = organization
+      allow(controller).to receive(:current_user) { user }
     end
 
     context "when time zone is UTC" do
@@ -83,6 +86,24 @@ module Decidim
         it "Time uses Rails timezone outside the controller scope" do
           expect(Time.zone.name).to eq("Azores")
         end
+      end
+    end
+
+    context "when time zone is defined by the user" do
+      let(:time_zone) { utc_time_zone }
+      let(:user_time_zone) { "London" }
+
+      it "controller uses London" do
+        expect(controller.organization_time_zone).to eq("London")
+      end
+    end
+
+    context "when user's time zone in not present" do
+      let(:time_zone) { utc_time_zone }
+      let(:user_time_zone) { "" }
+
+      it "controller uses time zone of organization" do
+        expect(controller.organization_time_zone).to eq(utc_time_zone)
       end
     end
   end

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -15,7 +15,8 @@ module Decidim
         remove_avatar: remove_avatar,
         personal_url: personal_url,
         about: about,
-        locale: "es"
+        locale: "es",
+        time_zone: time_zone
       ).with_context(
         current_organization: organization,
         current_user: user
@@ -34,6 +35,7 @@ module Decidim
     let(:remove_avatar) { false }
     let(:personal_url) { "http://example.org" }
     let(:about) { "This is a description about me" }
+    let(:time_zone) { "UTC" }
 
     context "with correct data" do
       it "is valid" do
@@ -148,6 +150,24 @@ module Decidim
 
       context "when it's not a valid URL" do
         let(:personal_url) { "foobar, aa" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+
+    describe "time_zone" do
+      context "when an empty time_zone" do
+        let(:time_zone) { "" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when time_zone has more 255 chars" do
+        let(:time_zone) { [*("A".."Z")].sample(256).join }
 
         it "is invalid" do
           expect(subject).not_to be_valid

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -162,7 +162,7 @@ module Decidim
         let(:time_zone) { "" }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_valid
         end
       end
 


### PR DESCRIPTION
Adds configurable timezone for users in order to make Decidim more usable for multi-zone organizations/countries

fixes #10  