### PR TITLE
ignore participatory spaces without models in highlighted elements

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -63,7 +63,8 @@ module Decidim
       scope :visible_meeting_for, lambda { |user|
         (all.distinct if user&.admin?) ||
           if user.present?
-            spaces = Decidim.participatory_space_registry.manifests.map do |manifest|
+            spaces = Decidim.participatory_space_registry.manifests.filter_map do |manifest|
+              next unless manifest.model_class_name.constantize.respond_to?(table_name)
               {
                 name: manifest.model_class_name.constantize.table_name.singularize,
                 class_name: manifest.model_class_name


### PR DESCRIPTION
fix some cases where meetings are extracted with user contexts.
This is relevant when participatory spaces don't have models associated